### PR TITLE
fix: pin & lock don't use the same html element

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -460,11 +460,11 @@ nav.post-controls .actions button.btn-icon-text, nav.post-controls .actions butt
   content: "";
   display: inline-block;
   vertical-align: text-top;
-  width: 13px;
+  width: 10px;
   height: 11px;
   transform: scale(1.8);
-  transform-origin: center center;
-  margin-right: 6px;
+  transform-origin: left;
+  margin-right: 12px;
   background: url($staffmod) no-repeat center/contain;
   pointer-events: none;
 }
@@ -474,11 +474,11 @@ nav.post-controls .actions button.btn-icon-text, nav.post-controls .actions butt
   content: "";
   display: inline-block;
   vertical-align: text-top;
-  width: 13px;
+  width: 10px;
   height: 11px;
   transform: scale(1.8);
-  transform-origin: center center;
-  margin-right: 6px;
+  transform-origin: left;
+  margin-right: 12px;
   background: url($fmod) no-repeat center/contain;
   pointer-events: none;
 }


### PR DESCRIPTION
- The main site's SVG class for locked threads is `d-icon-lock` not `locked`
- For pins: The classes are on the same element, not a child or sibling element
- Realign crowns on usercard (before and after pics below)

![image](https://github.com/user-attachments/assets/a8893e4c-b37d-4c41-bd69-997e6f6c5ddc)
![image](https://github.com/user-attachments/assets/bf4960e7-20d3-4696-918a-88574dcce673)


I'm no longer able to test this on a dev install of Discourse. I am only able to test locally in a browser. Please test prior to merge/deploy