### PR TITLE
fix: background colors for embedded tables in posts

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -557,3 +557,9 @@ a.topic-status.unpinned::before {/*For personally unpinned topics*/
 .topic-post.group-staffmod article.boxed .regular.contents {
   background: transparent;
 }
+
+/* Background for tables in posts */
+.topic-body .contents .md-table  {
+  --canvas-default:#2d2318;
+  --canvas-subtle:#1c160f;
+}


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/00697f9f-f911-41e0-9d4f-cb0304de59ca)

After:
![image](https://github.com/user-attachments/assets/a29c5616-c2ea-4607-8afe-bb89fe617228)
